### PR TITLE
bug / Transform의 GetWorldScale() 오류 수정 #20

### DIFF
--- a/Project/Engine/CTransform.cpp
+++ b/Project/Engine/CTransform.cpp
@@ -92,6 +92,11 @@ void CTransform::UpdateData()
 
 Vec3 CTransform::GetWorldScale()
 {
+	if (m_bAbsolute)
+	{
+		return m_vRelativeScale;
+	}
+
 	CGameObject* pParent = GetOwner()->GetParent();
 	Vec3 vWorldScale = m_vRelativeScale;
 


### PR DESCRIPTION
m_bAbsolute 값이 true라면 부모 값과 관계 없이 절대적인 값을 반환해야 한다.