### PR TITLE
Bug / #18 M_bSelected오류

### DIFF
--- a/Project/Client/Client.vcxproj.user
+++ b/Project/Client/Client.vcxproj.user
@@ -9,6 +9,6 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ShowAllFiles>true</ShowAllFiles>
+    <ShowAllFiles>false</ShowAllFiles>
   </PropertyGroup>
 </Project>

--- a/Project/Client/MenuUI.cpp
+++ b/Project/Client/MenuUI.cpp
@@ -176,6 +176,10 @@ void MenuUI::Level()
             CLevel* pLoadedLevel = CLevelSaveLoad::LoadLevel(L"Level//temp.lv");
             CLevelMgr::GetInst()->ChangeLevel(pLoadedLevel, LEVEL_STATE::STOP);
 
+            Outliner* pOutliner = (Outliner*)CImGuiMgr::GetInst()->FindUI("##Outliner");
+            auto m_Tree = pOutliner->GetTree()->GetSelectedNode();
+            m_Tree = nullptr;
+
             // Inspector 의 타겟정보를 nullptr 로 되돌리기
             Inspector* pInspector = (Inspector*)CImGuiMgr::GetInst()->FindUI("##Inspector");
             pInspector->SetTargetObject(nullptr);

--- a/Project/Client/MenuUI.cpp
+++ b/Project/Client/MenuUI.cpp
@@ -17,6 +17,8 @@
 
 #include "CImGuiMgr.h"
 #include "Inspector.h"
+#include "Outliner.h"
+#include "TreeUI.h"
 #include "CLevelSaveLoad.h"
 
 
@@ -157,6 +159,10 @@ void MenuUI::Level()
                 CLevelSaveLoad::SaveLevel(pCurLevel, L"Level//temp.lv");
             }
             
+            Outliner* pOutliner = (Outliner*)CImGuiMgr::GetInst()->FindUI("##Outliner");
+            auto m_Tree = pOutliner->GetTree()->GetSelectedNode();
+            m_Tree = nullptr;
+
             CLevelMgr::GetInst()->ChangeLevelState(LEVEL_STATE::PLAY);
         }
 

--- a/Project/Client/Outliner.h
+++ b/Project/Client/Outliner.h
@@ -14,6 +14,7 @@ private:
 
 public:
     virtual void render_update() override;
+    TreeUI* GetTree() { return m_Tree; }
 
 public:
     void ResetCurrentLevel();


### PR DESCRIPTION
프리팹 스폰 이후, Level 시작시,
Level이 변경되면서, obj가 사라지는데,
OutLiner에는 선택된 정보가 남아있어 m_bselected가 터지는 현상 수정

Outliner의 treeui를 가져와서 selected node를 nullptr 처리 해준다.