### PR TITLE
Refactor / #34 Collider2DUI

### DIFF
--- a/Project/Engine/CCollider2D.cpp
+++ b/Project/Engine/CCollider2D.cpp
@@ -63,7 +63,9 @@ void CCollider2D::finaltick()
 			}
 			else
 			{
-				GamePlayStatic::DrawDebugCircle(m_matColWorld, Vec3(0.f, 1.f, 0.f), false);
+				Vec3 vPos = GetOwner()->Transform()->GetWorldPos();
+				Vec2 vRadius = GetOwner()->Collider2D()->GetOffsetScale();
+				GamePlayStatic::DrawDebugCircle(vPos, vRadius.x, Vec3(0.f, 1.f, 0.f), false);
 			}
 		}
 		else
@@ -76,8 +78,7 @@ void CCollider2D::finaltick()
 			{
 				Vec3 vPos = GetOwner()->Transform()->GetWorldPos();
 				Vec2 vRadius = GetOwner()->Collider2D()->GetOffsetScale();
-				Vec2 vOffsetPos = GetOwner()->Collider2D()->GetOffsetPos();
-				GamePlayStatic::DrawDebugCircle(vPos, vOffsetPos, vRadius.x, Vec3(1.f, 0.f, 0.f), false);
+				GamePlayStatic::DrawDebugCircle(vPos, vRadius.x, Vec3(1.f, 0.f, 0.f), false);
 			}
 		}
 	}

--- a/Project/Engine/func.cpp
+++ b/Project/Engine/func.cpp
@@ -73,16 +73,13 @@ void GamePlayStatic::DrawDebugCircle(const Matrix& _WorldMat, Vec3 _Color, bool 
 	CRenderMgr::GetInst()->AddDebugShapeInfo(info);
 }
 
-void GamePlayStatic::DrawDebugCircle(Vec3 _vWorldPos, Vec2 _vOffsetPos, float _fRadius, Vec3 _Color, bool _bDepthTest, float _Duration)
+void GamePlayStatic::DrawDebugCircle(Vec3 _vWorldPos, float _fRadius, Vec3 _Color, bool _bDepthTest, float _Duration)
 {
 	tDebugShapeInfo info = {};
 	info.eShape = DEBUG_SHAPE::CIRCLE;
 
 	info.vWorldPos = _vWorldPos;
-	info.vWorldPos.x += _vOffsetPos.x;
-	info.vWorldPos.y += _vOffsetPos.y;
-
-	info.vWorldScale = Vec3(_fRadius, _fRadius, 1.f);
+	info.vWorldScale = Vec3(_fRadius * 2.f, _fRadius * 2.f, 1.f);
 	info.vWorldRot = Vec3(0.f, 0.f, 0.f);
 
 	info.matWorld = XMMatrixScaling(info.vWorldScale.x, info.vWorldScale.y, info.vWorldScale.z)

--- a/Project/Engine/func.h
+++ b/Project/Engine/func.h
@@ -15,7 +15,7 @@ namespace GamePlayStatic
 	void DrawDebugRect(Vec3 _vWorldPos, Vec3 _vWorldScale, Vec3 _vWorldRot, Vec3 _Color, bool _bDepthTest, float _Duration = 0.f);
 		
 	void DrawDebugCircle(const Matrix& _WorldMat, Vec3 _Color, bool _bDepthTest, float _Duration = 0.f);
-	void DrawDebugCircle(Vec3 _vWorldPos, Vec2 _vOffsetPos, float _fRadius, Vec3 _Color, bool _bDepthTest, float _Duration = 0.f);
+	void DrawDebugCircle(Vec3 _vWorldPos, float _fRadius, Vec3 _Color, bool _bDepthTest, float _Duration = 0.f);
 	
 	void DrawDebugCross(Vec3 _vWorldPos, float _fScale, Vec3 _Color, bool _bDepthTest, float _Duration = 0.f);
 


### PR DESCRIPTION
1. 원형 충돌체 Radius가 지름으로 적용되던 거 수정
2. 충돌체 렌더 방식 통일