### PR TITLE
Feat/follow up 240605 tue re

### DIFF
--- a/Project/Client/CCreateTempLevel.cpp
+++ b/Project/Client/CCreateTempLevel.cpp
@@ -199,8 +199,8 @@ void CCreateTempLevel::CreateTempLevel()
 		Ptr<CMeshData> pMeshData = nullptr;
 		CGameObject* pObj = nullptr;
 
-		//pMeshData = CAssetMgr::GetInst()->LoadFBX(L"fbx\\Monster.fbx");
-		pMeshData = CAssetMgr::GetInst()->FindAsset<CMeshData>(L"meshdata\\Monster.mdat");
+		pMeshData = CAssetMgr::GetInst()->LoadFBX(L"fbx\\Monster.fbx");
+		//pMeshData = CAssetMgr::GetInst()->FindAsset<CMeshData>(L"meshdata\\Monster.mdat");
 		pObj = pMeshData->Instantiate();
 		pObj->SetName(L"Monster");
 

--- a/Project/Client/CCreateTempLevel.cpp
+++ b/Project/Client/CCreateTempLevel.cpp
@@ -199,10 +199,10 @@ void CCreateTempLevel::CreateTempLevel()
 		Ptr<CMeshData> pMeshData = nullptr;
 		CGameObject* pObj = nullptr;
 
-		pMeshData = CAssetMgr::GetInst()->LoadFBX(L"fbx\\house.fbx");
-		//pMeshData = CAssetMgr::GetInst()->FindAsset<CMeshData>(L"meshdata\\house.mdat");
+		//pMeshData = CAssetMgr::GetInst()->LoadFBX(L"fbx\\Monster.fbx");
+		pMeshData = CAssetMgr::GetInst()->FindAsset<CMeshData>(L"meshdata\\Monster.mdat");
 		pObj = pMeshData->Instantiate();
-		pObj->SetName(L"House");
+		pObj->SetName(L"Monster");
 
 		pObj->Transform()->SetRelativePos(Vec3(0.f, 0.f, 100.f));
 

--- a/Project/Engine/CAnimation3DShader.cpp
+++ b/Project/Engine/CAnimation3DShader.cpp
@@ -1,0 +1,43 @@
+﻿#include "pch.h"
+#include "CAnimation3DShader.h"
+
+CAnimation3DShader::CAnimation3DShader()
+	: CComputeShader(256, 1, 1)
+	, m_pFrameDataBuffer(nullptr)
+	, m_pOffsetMatBuffer(nullptr)
+	, m_pOutputBuffer(nullptr)
+{
+	Create(L"shader\\animation.fx", "CS_Animation3D");
+}
+
+CAnimation3DShader::~CAnimation3DShader()
+{
+}
+
+int CAnimation3DShader::UpdateData()
+{
+	// 구조화버퍼 전달
+	m_pFrameDataBuffer->UpdateData_CS_SRV(16); // t16
+	m_pOffsetMatBuffer->UpdateData_CS_SRV(17); // t17
+	m_pOutputBuffer->UpdateData_CS_UAV(0);   // u0
+
+	return S_OK;
+}
+
+void CAnimation3DShader::UpdateGroupCount()
+{
+	UINT GroupX = (m_Const.iArr[0] / m_ThreadX) + 1;
+	UINT GroupY = 1;
+	UINT GroupZ = 1;
+}
+
+void CAnimation3DShader::Clear()
+{
+	m_pFrameDataBuffer->Clear_CS_SRV();
+	m_pOffsetMatBuffer->Clear_CS_SRV();
+	m_pOutputBuffer->Clear_CS_UAV();
+
+	m_pFrameDataBuffer = nullptr;
+	m_pOffsetMatBuffer = nullptr;
+	m_pOutputBuffer = nullptr;
+}

--- a/Project/Engine/CAnimation3DShader.h
+++ b/Project/Engine/CAnimation3DShader.h
@@ -1,0 +1,32 @@
+﻿#pragma once
+#include "CComputeShader.h"
+class CAnimation3DShader :
+    public CComputeShader
+{
+private:
+    CStructuredBuffer* m_pFrameDataBuffer;			// t16
+    CStructuredBuffer* m_pOffsetMatBuffer;			// t17 
+    CStructuredBuffer* m_pOutputBuffer;				// u0
+
+
+public:
+    // g_int_0 : BonCount, g_int_1 : Frame Index
+    void SetBoneCount(int _iBoneCount) { m_Const.iArr[0] = _iBoneCount; }
+    void SetFrameIndex(int _iFrameIdx) { m_Const.iArr[1] = _iFrameIdx; }
+    void SetNextFrameIdx(int _iFrameIdx) { m_Const.iArr[2] = _iFrameIdx; }
+    void SetFrameRatio(float _fFrameRatio) { m_Const.fArr[0] = _fFrameRatio; }
+    void SetFrameDataBuffer(CStructuredBuffer* _buffer) { m_pFrameDataBuffer = _buffer; }
+    void SetOffsetMatBuffer(CStructuredBuffer* _buffer) { m_pOffsetMatBuffer = _buffer; }
+    void SetOutputBuffer(CStructuredBuffer* _buffer) { m_pOutputBuffer = _buffer; }
+
+
+public:
+    virtual int UpdateData() override;
+    virtual void UpdateGroupCount() override;
+    virtual void Clear() override;
+
+
+public:
+    CAnimation3DShader();
+    ~CAnimation3DShader();
+};

--- a/Project/Engine/CAnimator3D.cpp
+++ b/Project/Engine/CAnimator3D.cpp
@@ -53,7 +53,7 @@ void CAnimator3D::finaltick()
 {
 	m_dCurTime = 0.f;
 	// 현재 재생중인 Clip 의 시간을 진행한다.
-	m_vecClipUpdateTime[m_iCurClip] += DT;
+	m_vecClipUpdateTime[m_iCurClip] += DTd_ENGINE;
 
 	if (m_vecClipUpdateTime[m_iCurClip] >= m_pVecClip->at(m_iCurClip).dTimeLength)
 	{
@@ -144,7 +144,7 @@ void CAnimator3D::check_mesh(Ptr<CMesh> _pMesh)
 	UINT iBoneCount = _pMesh->GetBoneCount();
 	if (m_pBoneFinalMatBuffer->GetElementCount() != iBoneCount)
 	{
-		m_pBoneFinalMatBuffer->Create(sizeof(Matrix), iBoneCount, SB_TYPE::READ_WRITE, false, nullptr);
+		m_pBoneFinalMatBuffer->Create(sizeof(Matrix), iBoneCount, SB_READ_TYPE::READ_WRITE, false, nullptr);
 	}
 }
 
@@ -152,6 +152,14 @@ void CAnimator3D::SaveToFile(FILE* _pFile)
 {
 }
 
+void CAnimator3D::SaveToFile(ofstream& fout)
+{
+}
+
 void CAnimator3D::LoadFromFile(FILE* _pFile)
+{
+}
+
+void CAnimator3D::LoadFromFile(ifstream& fin)
 {
 }

--- a/Project/Engine/CAnimator3D.cpp
+++ b/Project/Engine/CAnimator3D.cpp
@@ -1,0 +1,157 @@
+﻿#include "pch.h"
+
+#include "CAnimator3D.h"
+
+#include "CTimeMgr.h"
+#include "CMeshRender.h"
+#include "CStructuredBuffer.h"
+#include "CAssetMgr.h"
+#include "CAnimation3DShader.h"
+#include "CKeyMgr.h"
+
+
+CAnimator3D::CAnimator3D()
+	: m_pVecBones(nullptr)
+	, m_pVecClip(nullptr)
+	, m_iCurClip(0)
+	, m_dCurTime(0.)
+	, m_iFrameCount(30)
+	, m_pBoneFinalMatBuffer(nullptr)
+	, m_bFinalMatUpdate(false)
+	, m_iFrameIdx(0)
+	, m_iNextFrameIdx(0)
+	, m_fRatio(0.f)
+	, CComponent(COMPONENT_TYPE::ANIMATOR3D)
+{
+	m_pBoneFinalMatBuffer = new CStructuredBuffer;
+}
+
+CAnimator3D::CAnimator3D(const CAnimator3D& _origin)
+	: m_pVecBones(_origin.m_pVecBones)
+	, m_pVecClip(_origin.m_pVecClip)
+	, m_iCurClip(_origin.m_iCurClip)
+	, m_dCurTime(_origin.m_dCurTime)
+	, m_iFrameCount(_origin.m_iFrameCount)
+	, m_pBoneFinalMatBuffer(nullptr)
+	, m_bFinalMatUpdate(false)
+	, m_iFrameIdx(_origin.m_iFrameIdx)
+	, m_iNextFrameIdx(_origin.m_iNextFrameIdx)
+	, m_fRatio(_origin.m_fRatio)
+	, CComponent(COMPONENT_TYPE::ANIMATOR3D)
+{
+	m_pBoneFinalMatBuffer = new CStructuredBuffer;
+}
+
+CAnimator3D::~CAnimator3D()
+{
+	if (nullptr != m_pBoneFinalMatBuffer)
+		delete m_pBoneFinalMatBuffer;
+}
+
+
+void CAnimator3D::finaltick()
+{
+	m_dCurTime = 0.f;
+	// 현재 재생중인 Clip 의 시간을 진행한다.
+	m_vecClipUpdateTime[m_iCurClip] += DT;
+
+	if (m_vecClipUpdateTime[m_iCurClip] >= m_pVecClip->at(m_iCurClip).dTimeLength)
+	{
+		m_vecClipUpdateTime[m_iCurClip] = 0.f;
+	}
+
+	m_dCurTime = m_pVecClip->at(m_iCurClip).dStartTime + m_vecClipUpdateTime[m_iCurClip];
+
+	// 현재 프레임 인덱스 구하기
+	double dFrameIdx = m_dCurTime * (double)m_iFrameCount;
+	m_iFrameIdx = (int)(dFrameIdx);
+
+	// 다음 프레임 인덱스
+	if (m_iFrameIdx >= m_pVecClip->at(0).iFrameLength - 1)
+		m_iNextFrameIdx = m_iFrameIdx;	// 끝이면 현재 인덱스를 유지
+	else
+		m_iNextFrameIdx = m_iFrameIdx + 1;
+
+	// 프레임간의 시간에 따른 비율을 구해준다.
+	m_fRatio = (float)(dFrameIdx - (double)m_iFrameIdx);
+
+	// 컴퓨트 쉐이더 연산여부
+	m_bFinalMatUpdate = false;
+}
+
+void CAnimator3D::SetAnimClip(const vector<tMTAnimClip>* _vecAnimClip)
+{
+	m_pVecClip = _vecAnimClip;
+	m_vecClipUpdateTime.resize(m_pVecClip->size());
+
+	// 테스트 코드
+	/*static float fTime = 0.f;
+	fTime += 1.f;
+	m_vecClipUpdateTime[0] = fTime;*/
+}
+
+
+void CAnimator3D::UpdateData()
+{
+	if (!m_bFinalMatUpdate)
+	{
+		// Animation3D Update Compute Shader
+		CAnimation3DShader* pUpdateShader = (CAnimation3DShader*)CAssetMgr::GetInst()->FindAsset<CComputeShader>(L"Animation3DUpdateCS").Get();
+
+		// Bone Data
+		Ptr<CMesh> pMesh = MeshRender()->GetMesh();
+		check_mesh(pMesh);
+
+		pUpdateShader->SetFrameDataBuffer(pMesh->GetBoneFrameDataBuffer());
+		pUpdateShader->SetOffsetMatBuffer(pMesh->GetBoneOffsetBuffer());
+		pUpdateShader->SetOutputBuffer(m_pBoneFinalMatBuffer);
+
+		UINT iBoneCount = (UINT)m_pVecBones->size();
+		pUpdateShader->SetBoneCount(iBoneCount);
+		pUpdateShader->SetFrameIndex(m_iFrameIdx);
+		pUpdateShader->SetNextFrameIdx(m_iNextFrameIdx);
+		pUpdateShader->SetFrameRatio(m_fRatio);
+
+		// 업데이트 쉐이더 실행
+		pUpdateShader->Execute();
+
+		m_bFinalMatUpdate = true;
+	}
+
+	// t30 레지스터에 최종행렬 데이터(구조버퍼) 바인딩		
+	m_pBoneFinalMatBuffer->UpdateData(30);
+}
+
+void CAnimator3D::ClearData()
+{
+	m_pBoneFinalMatBuffer->Clear(30);
+
+	UINT iMtrlCount = MeshRender()->GetMtrlCount();
+	Ptr<CMaterial> pMtrl = nullptr;
+	for (UINT i = 0; i < iMtrlCount; ++i)
+	{
+		pMtrl = MeshRender()->GetSharedMaterial(i);
+		if (nullptr == pMtrl)
+			continue;
+
+		pMtrl->SetAnim3D(false); // Animation Mesh 알리기
+		pMtrl->SetBoneCount(0);
+	}
+}
+
+void CAnimator3D::check_mesh(Ptr<CMesh> _pMesh)
+{
+	UINT iBoneCount = _pMesh->GetBoneCount();
+	if (m_pBoneFinalMatBuffer->GetElementCount() != iBoneCount)
+	{
+		m_pBoneFinalMatBuffer->Create(sizeof(Matrix), iBoneCount, SB_TYPE::READ_WRITE, false, nullptr);
+	}
+}
+
+void CAnimator3D::SaveToFile(FILE* _pFile)
+{
+}
+
+void CAnimator3D::LoadFromFile(FILE* _pFile)
+{
+}

--- a/Project/Engine/CAnimator3D.h
+++ b/Project/Engine/CAnimator3D.h
@@ -1,0 +1,56 @@
+﻿#pragma once
+#include "CComponent.h"
+
+#include "Ptr.h"
+#include "CTexture.h"
+#include "CMaterial.h"
+#include "CMesh.h"
+
+class CStructuredBuffer;
+
+class CAnimator3D :
+    public CComponent
+{
+private:
+    const vector<tMTBone>* m_pVecBones;
+    const vector<tMTAnimClip>* m_pVecClip;
+
+    vector<float>				m_vecClipUpdateTime;
+    vector<Matrix>				m_vecFinalBoneMat; // 텍스쳐에 전달할 최종 행렬정보
+    int							m_iFrameCount; // 30
+    double						m_dCurTime;
+    int							m_iCurClip; // 클립 인덱스	
+
+    int							m_iFrameIdx; // 클립의 현재 프레임
+    int							m_iNextFrameIdx; // 클립의 다음 프레임
+    float						m_fRatio;	// 프레임 사이 비율
+
+    CStructuredBuffer* m_pBoneFinalMatBuffer;  // 특정 프레임의 최종 행렬
+    bool						m_bFinalMatUpdate; // 최종행렬 연산 수행여부
+
+public:
+    virtual void finaltick() override;
+    void UpdateData();
+
+public:
+    void SetBones(const vector<tMTBone>* _vecBones) { m_pVecBones = _vecBones; m_vecFinalBoneMat.resize(m_pVecBones->size()); }
+    void SetAnimClip(const vector<tMTAnimClip>* _vecAnimClip);
+    void SetClipTime(int _iClipIdx, float _fTime) { m_vecClipUpdateTime[_iClipIdx] = _fTime; }
+
+    CStructuredBuffer* GetFinalBoneMat() { return m_pBoneFinalMatBuffer; }
+    UINT GetBoneCount() { return (UINT)m_pVecBones->size(); }
+    void ClearData();
+
+private:
+    void check_mesh(Ptr<CMesh> _pMesh);
+
+public:
+    virtual void SaveToFile(FILE* _pFile) override;
+    virtual void LoadFromFile(FILE* _pFile) override;
+    CLONE(CAnimator3D);
+
+public:
+    CAnimator3D();
+    CAnimator3D(const CAnimator3D& _origin);
+    ~CAnimator3D();
+};

--- a/Project/Engine/CAnimator3D.h
+++ b/Project/Engine/CAnimator3D.h
@@ -46,7 +46,9 @@ private:
 
 public:
     virtual void SaveToFile(FILE* _pFile) override;
+    virtual void SaveToFile(ofstream& fout) override;
     virtual void LoadFromFile(FILE* _pFile) override;
+    virtual void LoadFromFile(ifstream& fin) override;
     CLONE(CAnimator3D);
 
 public:

--- a/Project/Engine/CAsset.h
+++ b/Project/Engine/CAsset.h
@@ -20,10 +20,11 @@ public:
     ASSET_TYPE GetType() { return m_Type; }
     bool IsEngineAsset() { return m_bEngineAsset; }
 
-private:
+protected:
     void SetKey(const wstring& _Key) { m_Key = _Key; }
     void SetRelativePath(const wstring& _RelativePath) { m_RelativePath = _RelativePath; }
 
+private:
     void AddRef()  {  ++m_RefCount;  }
     void Release() 
     { 

--- a/Project/Engine/CAssetMgr.cpp
+++ b/Project/Engine/CAssetMgr.cpp
@@ -457,7 +457,7 @@ Ptr<CMeshData> CAssetMgr::LoadFBX(const wstring& _strPath)
 	m_mapAsset[(UINT)ASSET_TYPE::MESHDATA].insert(make_pair(strName, pMeshData.Get()));
 
 	// meshdata 를 실제파일로 저장
-	//pMeshData->Save(strName);
+	pMeshData->Save(strName);
 
 	return pMeshData;
 }

--- a/Project/Engine/CAssetMgr_init.cpp
+++ b/Project/Engine/CAssetMgr_init.cpp
@@ -1069,6 +1069,7 @@ void CAssetMgr::CreateDefaultMaterial()
 
 #include "CSetColorShader.h"
 #include "CParticleUpdate.h"
+#include "CAnimation3DShader.h"
 void CAssetMgr::CreateDefaultComputeShader()
 {
 	Ptr<CComputeShader> pShader = nullptr;
@@ -1080,6 +1081,10 @@ void CAssetMgr::CreateDefaultComputeShader()
 	// ParticleUpdateShader
 	pShader = new CParticleUpdate;
 	AddAsset(SHADER_particleupdate, pShader.Get());
+
+	// Animation3DUpdateShader
+	pShader = new CAnimation3DShader;
+	AddAsset(L"Animation3DUpdateCS", pShader.Get());
 }
 
 

--- a/Project/Engine/CComponent.h
+++ b/Project/Engine/CComponent.h
@@ -28,7 +28,8 @@ public:
     inline class CCamera* Camera() { return GetOwner()->Camera();}
     inline class CStateMachine* StateMachine() { return GetOwner()->StateMachine();}
     inline class CCollider2D* Collider2D() { return GetOwner()->Collider2D();}
-    inline class CAnimator2D* Animator2D() { return GetOwner()->Animator2D();}
+    inline class CAnimator2D* Animator2D() { return GetOwner()->Animator2D(); }
+    inline class CAnimator3D* Animator3D() { return GetOwner()->Animator3D();}
     inline class CLight2D* Light2D() { return GetOwner()->Light2D();}
     inline class CLight3D* Light3D() { return GetOwner()->Light3D();}
     inline class CParticleSystem* ParticleSystem() { return GetOwner()->ParticleSystem(); }

--- a/Project/Engine/CGameObject.h
+++ b/Project/Engine/CGameObject.h
@@ -40,6 +40,7 @@ public:
     inline class CStateMachine* StateMachine() { return (CStateMachine*)m_arrCom[(UINT)COMPONENT_TYPE::STATEMACHINE]; }
     inline class CCollider2D* Collider2D() { return (CCollider2D*)m_arrCom[(UINT)COMPONENT_TYPE::COLLIDER2D]; }
     inline class CAnimator2D* Animator2D() { return (CAnimator2D*)m_arrCom[(UINT)COMPONENT_TYPE::ANIMATOR2D]; }
+    inline class CAnimator3D* Animator3D() { return (CAnimator3D*)m_arrCom[(UINT)COMPONENT_TYPE::ANIMATOR3D]; }
     inline class CLight2D* Light2D() { return (CLight2D*)m_arrCom[(UINT)COMPONENT_TYPE::LIGHT2D]; }
     inline class CLight3D* Light3D() { return (CLight3D*)m_arrCom[(UINT)COMPONENT_TYPE::LIGHT3D]; }
     inline class CParticleSystem* ParticleSystem() { return (CParticleSystem*)m_arrCom[(UINT)COMPONENT_TYPE::PARTICLESYSTEM]; }

--- a/Project/Engine/CGraphicsShader.cpp
+++ b/Project/Engine/CGraphicsShader.cpp
@@ -49,7 +49,7 @@ int CGraphicsShader::CreateVertexShader(const wstring& _strRelativePath, const s
 	m_VSFuncName = ToString(_strFuncName);
 
 	// 정점 구조정보(Layout) 생성
-	D3D11_INPUT_ELEMENT_DESC arrElement[6] = {};
+	D3D11_INPUT_ELEMENT_DESC arrElement[8] = {};
 
 	arrElement[0].InputSlot = 0;
 	arrElement[0].InputSlotClass = D3D11_INPUT_PER_VERTEX_DATA;
@@ -99,9 +99,24 @@ int CGraphicsShader::CreateVertexShader(const wstring& _strRelativePath, const s
 	arrElement[5].AlignedByteOffset = 60;
 	arrElement[5].Format = DXGI_FORMAT_R32G32B32_FLOAT;
 
+	arrElement[6].SemanticName = "BLENDWEIGHT";
+	arrElement[6].SemanticIndex = 0;
+	arrElement[6].AlignedByteOffset = 72;
+	arrElement[6].Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+	arrElement[6].InputSlot = 0;
+	arrElement[6].InputSlotClass = D3D11_INPUT_PER_VERTEX_DATA;
+	arrElement[6].InstanceDataStepRate = 0;
+
+	arrElement[7].SemanticName = "BLENDINDICES";
+	arrElement[7].SemanticIndex = 0;
+	arrElement[7].AlignedByteOffset = 88;
+	arrElement[7].Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+	arrElement[7].InputSlot = 0;
+	arrElement[7].InputSlotClass = D3D11_INPUT_PER_VERTEX_DATA;
+	arrElement[7].InstanceDataStepRate = 0;
 
 	// Layout 생성
-	DEVICE->CreateInputLayout(arrElement, 6
+	DEVICE->CreateInputLayout(arrElement, 8
 							, m_VSBlob->GetBufferPointer()
 							, m_VSBlob->GetBufferSize()
 							, m_Layout.GetAddressOf());

--- a/Project/Engine/CMaterial.h
+++ b/Project/Engine/CMaterial.h
@@ -28,6 +28,9 @@ public:
 		m_Const.mtrl.vEmv = _vEmis;
 	}
 
+	void SetAnim3D(bool _bTrue) { m_Const.arrAnimData[0] = (int)_bTrue; }
+	void SetBoneCount(int _iBoneCount) { m_Const.arrAnimData[1] = _iBoneCount; }
+
 	void* GetScalarParam(SCALAR_PARAM _ParamType);
 	Ptr<CTexture> GetTexParam(TEX_PARAM _ParamType) { return m_arrTex[(UINT)_ParamType]; }
 

--- a/Project/Engine/CMesh.cpp
+++ b/Project/Engine/CMesh.cpp
@@ -20,6 +20,12 @@ CMesh::~CMesh()
 		if (nullptr != m_vecIdxInfo[i].pIdxSysMem)
 			delete m_vecIdxInfo[i].pIdxSysMem;
 	}
+
+	if (nullptr != m_pBoneFrameData)
+		delete m_pBoneFrameData;
+
+	if (nullptr != m_pBoneOffset)
+		delete m_pBoneOffset;
 }
 
 CMesh* CMesh::CreateFromContainer(CFBXLoader& _loader)
@@ -48,8 +54,8 @@ CMesh* CMesh::CreateFromContainer(CFBXLoader& _loader)
 		pSys[i].vNormal = container->vecNormal[i];
 		pSys[i].vTangent = container->vecTangent[i];
 		pSys[i].vBinormal = container->vecBinormal[i];
-		//pSys[i].vWeights = container->vecWeights[i];
-		//pSys[i].vIndices = container->vecIndices[i];
+		pSys[i].vWeights = container->vecWeights[i];
+		pSys[i].vIndices = container->vecIndices[i];
 	}
 
 	ComPtr<ID3D11Buffer> pVB = NULL;
@@ -92,6 +98,95 @@ CMesh* CMesh::CreateFromContainer(CFBXLoader& _loader)
 		info.pIB = pIB;
 
 		pMesh->m_vecIdxInfo.push_back(info);
+	}
+
+	// Animation3D
+	if (!container->bAnimation)
+		return pMesh;
+
+	vector<tBone*>& vecBone = _loader.GetBones();
+	UINT iFrameCount = 0;
+	for (UINT i = 0; i < vecBone.size(); ++i)
+	{
+		tMTBone bone = {};
+		bone.iDepth = vecBone[i]->iDepth;
+		bone.iParentIndx = vecBone[i]->iParentIndx;
+		bone.matBone = GetMatrixFromFbxMatrix(vecBone[i]->matBone);
+		bone.matOffset = GetMatrixFromFbxMatrix(vecBone[i]->matOffset);
+		bone.strBoneName = vecBone[i]->strBoneName;
+
+		for (UINT j = 0; j < vecBone[i]->vecKeyFrame.size(); ++j)
+		{
+			tMTKeyFrame tKeyframe = {};
+			tKeyframe.dTime = vecBone[i]->vecKeyFrame[j].dTime;
+			tKeyframe.iFrame = j;
+			tKeyframe.vTranslate.x = (float)vecBone[i]->vecKeyFrame[j].matTransform.GetT().mData[0];
+			tKeyframe.vTranslate.y = (float)vecBone[i]->vecKeyFrame[j].matTransform.GetT().mData[1];
+			tKeyframe.vTranslate.z = (float)vecBone[i]->vecKeyFrame[j].matTransform.GetT().mData[2];
+
+			tKeyframe.vScale.x = (float)vecBone[i]->vecKeyFrame[j].matTransform.GetS().mData[0];
+			tKeyframe.vScale.y = (float)vecBone[i]->vecKeyFrame[j].matTransform.GetS().mData[1];
+			tKeyframe.vScale.z = (float)vecBone[i]->vecKeyFrame[j].matTransform.GetS().mData[2];
+
+			tKeyframe.qRot.x = (float)vecBone[i]->vecKeyFrame[j].matTransform.GetQ().mData[0];
+			tKeyframe.qRot.y = (float)vecBone[i]->vecKeyFrame[j].matTransform.GetQ().mData[1];
+			tKeyframe.qRot.z = (float)vecBone[i]->vecKeyFrame[j].matTransform.GetQ().mData[2];
+			tKeyframe.qRot.w = (float)vecBone[i]->vecKeyFrame[j].matTransform.GetQ().mData[3];
+
+			bone.vecKeyFrame.push_back(tKeyframe);
+		}
+
+		iFrameCount = max(iFrameCount, (UINT)bone.vecKeyFrame.size());
+
+		pMesh->m_vecBones.push_back(bone);
+	}
+
+	vector<tAnimClip*>& vecAnimClip = _loader.GetAnimClip();
+
+	for (UINT i = 0; i < vecAnimClip.size(); ++i)
+	{
+		tMTAnimClip tClip = {};
+
+		tClip.strAnimName = vecAnimClip[i]->strName;
+		tClip.dStartTime = vecAnimClip[i]->tStartTime.GetSecondDouble();
+		tClip.dEndTime = vecAnimClip[i]->tEndTime.GetSecondDouble();
+		tClip.dTimeLength = tClip.dEndTime - tClip.dStartTime;
+
+		tClip.iStartFrame = (int)vecAnimClip[i]->tStartTime.GetFrameCount(vecAnimClip[i]->eMode);
+		tClip.iEndFrame = (int)vecAnimClip[i]->tEndTime.GetFrameCount(vecAnimClip[i]->eMode);
+		tClip.iFrameLength = tClip.iEndFrame - tClip.iStartFrame;
+		tClip.eMode = vecAnimClip[i]->eMode;
+
+		pMesh->m_vecAnimClip.push_back(tClip);
+	}
+
+	// Animation 이 있는 Mesh 경우 structuredbuffer 만들어두기
+	if (pMesh->IsAnimMesh())
+	{
+		// BoneOffet 행렬
+		vector<Matrix> vecOffset;
+		vector<tFrameTrans> vecFrameTrans;
+		vecFrameTrans.resize((UINT)pMesh->m_vecBones.size() * iFrameCount);
+
+		for (size_t i = 0; i < pMesh->m_vecBones.size(); ++i)
+		{
+			vecOffset.push_back(pMesh->m_vecBones[i].matOffset);
+
+			for (size_t j = 0; j < pMesh->m_vecBones[i].vecKeyFrame.size(); ++j)
+			{
+				vecFrameTrans[(UINT)pMesh->m_vecBones.size() * j + i]
+					= tFrameTrans{ Vec4(pMesh->m_vecBones[i].vecKeyFrame[j].vTranslate, 0.f)
+					, Vec4(pMesh->m_vecBones[i].vecKeyFrame[j].vScale, 0.f)
+					, pMesh->m_vecBones[i].vecKeyFrame[j].qRot };
+			}
+		}
+
+		pMesh->m_pBoneOffset = new CStructuredBuffer;
+		pMesh->m_pBoneOffset->Create(sizeof(Matrix), (UINT)vecOffset.size(), SB_TYPE::READ_ONLY, false, vecOffset.data());
+
+		pMesh->m_pBoneFrameData = new CStructuredBuffer;
+		pMesh->m_pBoneFrameData->Create(sizeof(tFrameTrans), (UINT)vecOffset.size() * iFrameCount
+			, SB_TYPE::READ_ONLY, false, vecFrameTrans.data());
 	}
 
 	return pMesh;
@@ -179,4 +274,223 @@ void CMesh::render_asparticle(UINT _ParticleCount)
 	UpdateData(0);
 
 	CONTEXT->DrawIndexedInstanced(m_vecIdxInfo[0].iIdxCount, _ParticleCount, 0, 0, 0);
+}
+
+int CMesh::Save(const wstring& _strRelativePath)
+{
+	// 상대경로 저장	
+	SetRelativePath(_strRelativePath);
+
+	// 파일 경로 만들기
+	wstring strFilePath = CPathMgr::GetContentPath() + _strRelativePath;
+
+	// 파일 쓰기모드로 열기
+	FILE* pFile = nullptr;
+	errno_t err = _wfopen_s(&pFile, strFilePath.c_str(), L"wb");
+	assert(pFile);
+
+	// 키값, 상대 경로	
+	SaveWString(GetName(), pFile);
+	SaveWString(GetKey(), pFile);
+	SaveWString(GetRelativePath(), pFile);
+
+	// 정점 데이터 저장				
+	int iByteSize = m_VBDesc.ByteWidth;
+	fwrite(&iByteSize, sizeof(int), 1, pFile);
+	fwrite(m_VtxSysMem, iByteSize, 1, pFile);
+
+	// 인덱스 정보
+	UINT iMtrlCount = (UINT)m_vecIdxInfo.size();
+	fwrite(&iMtrlCount, sizeof(int), 1, pFile);
+
+	UINT iIdxBuffSize = 0;
+	for (UINT i = 0; i < iMtrlCount; ++i)
+	{
+		fwrite(&m_vecIdxInfo[i], sizeof(tIndexInfo), 1, pFile);
+		fwrite(m_vecIdxInfo[i].pIdxSysMem
+			, m_vecIdxInfo[i].iIdxCount * sizeof(UINT)
+			, 1, pFile);
+	}
+
+	// Animation3D 정보 
+	UINT iCount = (UINT)m_vecAnimClip.size();
+	fwrite(&iCount, sizeof(int), 1, pFile);
+	for (UINT i = 0; i < iCount; ++i)
+	{
+		SaveWString(m_vecAnimClip[i].strAnimName, pFile);
+		fwrite(&m_vecAnimClip[i].dStartTime, sizeof(double), 1, pFile);
+		fwrite(&m_vecAnimClip[i].dEndTime, sizeof(double), 1, pFile);
+		fwrite(&m_vecAnimClip[i].dTimeLength, sizeof(double), 1, pFile);
+		fwrite(&m_vecAnimClip[i].eMode, sizeof(int), 1, pFile);
+		fwrite(&m_vecAnimClip[i].fUpdateTime, sizeof(float), 1, pFile);
+		fwrite(&m_vecAnimClip[i].iStartFrame, sizeof(int), 1, pFile);
+		fwrite(&m_vecAnimClip[i].iEndFrame, sizeof(int), 1, pFile);
+		fwrite(&m_vecAnimClip[i].iFrameLength, sizeof(int), 1, pFile);
+	}
+
+	iCount = (UINT)m_vecBones.size();
+	fwrite(&iCount, sizeof(int), 1, pFile);
+
+	for (UINT i = 0; i < iCount; ++i)
+	{
+		SaveWString(m_vecBones[i].strBoneName, pFile);
+		fwrite(&m_vecBones[i].iDepth, sizeof(int), 1, pFile);
+		fwrite(&m_vecBones[i].iParentIndx, sizeof(int), 1, pFile);
+		fwrite(&m_vecBones[i].matBone, sizeof(Matrix), 1, pFile);
+		fwrite(&m_vecBones[i].matOffset, sizeof(Matrix), 1, pFile);
+
+		int iFrameCount = (int)m_vecBones[i].vecKeyFrame.size();
+		fwrite(&iFrameCount, sizeof(int), 1, pFile);
+
+		for (int j = 0; j < m_vecBones[i].vecKeyFrame.size(); ++j)
+		{
+			fwrite(&m_vecBones[i].vecKeyFrame[j], sizeof(tMTKeyFrame), 1, pFile);
+		}
+	}
+
+	fclose(pFile);
+
+
+	return S_OK;
+}
+
+int CMesh::Load(const wstring& _strFilePath)
+{
+	// 읽기모드로 파일열기
+	FILE* pFile = nullptr;
+	_wfopen_s(&pFile, _strFilePath.c_str(), L"rb");
+
+	// 키값, 상대경로
+	wstring strName, strKey, strRelativePath;
+	LoadWString(strName, pFile);
+	LoadWString(strKey, pFile);
+	LoadWString(strRelativePath, pFile);
+
+	SetName(strName);
+	SetKey(strKey);
+	SetRelativePath(strRelativePath);
+
+	// 정점데이터
+	UINT iByteSize = 0;
+	fread(&iByteSize, sizeof(int), 1, pFile);
+
+	m_VtxSysMem = (Vtx*)malloc(iByteSize);
+	fread(m_VtxSysMem, 1, iByteSize, pFile);
+
+
+	D3D11_BUFFER_DESC tDesc = {};
+	tDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+	tDesc.ByteWidth = iByteSize;
+	tDesc.Usage = D3D11_USAGE_DEFAULT;
+
+	D3D11_SUBRESOURCE_DATA tSubData = {};
+	tSubData.pSysMem = m_VtxSysMem;
+
+	if (FAILED(DEVICE->CreateBuffer(&tDesc, &tSubData, m_VB.GetAddressOf())))
+	{
+		assert(nullptr);
+	}
+
+	// 인덱스 정보
+	UINT iMtrlCount = 0;
+	fread(&iMtrlCount, sizeof(int), 1, pFile);
+
+	for (UINT i = 0; i < iMtrlCount; ++i)
+	{
+		tIndexInfo info = {};
+		fread(&info, sizeof(tIndexInfo), 1, pFile);
+
+		UINT iByteWidth = info.iIdxCount * sizeof(UINT);
+
+		void* pSysMem = malloc(iByteWidth);
+		info.pIdxSysMem = pSysMem;
+		fread(info.pIdxSysMem, iByteWidth, 1, pFile);
+
+		tSubData.pSysMem = info.pIdxSysMem;
+
+		if (FAILED(DEVICE->CreateBuffer(&info.tIBDesc, &tSubData, info.pIB.GetAddressOf())))
+		{
+			assert(nullptr);
+		}
+
+		m_vecIdxInfo.push_back(info);
+	}
+
+	// Animation3D 정보 읽기
+	int iCount = 0;
+	fread(&iCount, sizeof(int), 1, pFile);
+	for (int i = 0; i < iCount; ++i)
+	{
+		tMTAnimClip tClip = {};
+
+		LoadWString(tClip.strAnimName, pFile);
+		fread(&tClip.dStartTime, sizeof(double), 1, pFile);
+		fread(&tClip.dEndTime, sizeof(double), 1, pFile);
+		fread(&tClip.dTimeLength, sizeof(double), 1, pFile);
+		fread(&tClip.eMode, sizeof(int), 1, pFile);
+		fread(&tClip.fUpdateTime, sizeof(float), 1, pFile);
+		fread(&tClip.iStartFrame, sizeof(int), 1, pFile);
+		fread(&tClip.iEndFrame, sizeof(int), 1, pFile);
+		fread(&tClip.iFrameLength, sizeof(int), 1, pFile);
+
+		m_vecAnimClip.push_back(tClip);
+	}
+
+	iCount = 0;
+	fread(&iCount, sizeof(int), 1, pFile);
+	m_vecBones.resize(iCount);
+
+	UINT _iFrameCount = 0;
+	for (int i = 0; i < iCount; ++i)
+	{
+		LoadWString(m_vecBones[i].strBoneName, pFile);
+		fread(&m_vecBones[i].iDepth, sizeof(int), 1, pFile);
+		fread(&m_vecBones[i].iParentIndx, sizeof(int), 1, pFile);
+		fread(&m_vecBones[i].matBone, sizeof(Matrix), 1, pFile);
+		fread(&m_vecBones[i].matOffset, sizeof(Matrix), 1, pFile);
+
+		UINT iFrameCount = 0;
+		fread(&iFrameCount, sizeof(int), 1, pFile);
+		m_vecBones[i].vecKeyFrame.resize(iFrameCount);
+		_iFrameCount = max(_iFrameCount, iFrameCount);
+		for (UINT j = 0; j < iFrameCount; ++j)
+		{
+			fread(&m_vecBones[i].vecKeyFrame[j], sizeof(tMTKeyFrame), 1, pFile);
+		}
+	}
+
+	// Animation 이 있는 Mesh 경우 Bone StructuredBuffer 만들기
+	if (m_vecAnimClip.size() > 0 && m_vecBones.size() > 0)
+	{
+		wstring strBone = GetName();
+
+		// BoneOffet 행렬
+		vector<Matrix> vecOffset;
+		vector<tFrameTrans> vecFrameTrans;
+		vecFrameTrans.resize((UINT)m_vecBones.size() * _iFrameCount);
+
+		for (size_t i = 0; i < m_vecBones.size(); ++i)
+		{
+			vecOffset.push_back(m_vecBones[i].matOffset);
+
+			for (size_t j = 0; j < m_vecBones[i].vecKeyFrame.size(); ++j)
+			{
+				vecFrameTrans[(UINT)m_vecBones.size() * j + i]
+					= tFrameTrans{ Vec4(m_vecBones[i].vecKeyFrame[j].vTranslate, 0.f)
+					, Vec4(m_vecBones[i].vecKeyFrame[j].vScale, 0.f)
+					, Vec4(m_vecBones[i].vecKeyFrame[j].qRot) };
+			}
+		}
+
+		m_pBoneOffset = new CStructuredBuffer;
+		m_pBoneOffset->Create(sizeof(Matrix), (UINT)vecOffset.size(), SB_TYPE::READ_ONLY, false, vecOffset.data());
+
+		m_pBoneFrameData = new CStructuredBuffer;
+		m_pBoneFrameData->Create(sizeof(tFrameTrans), (UINT)vecOffset.size() * (UINT)_iFrameCount
+			, SB_TYPE::READ_ONLY, false, vecFrameTrans.data());
+	}
+
+	fclose(pFile);
+
+	return S_OK;
 }

--- a/Project/Engine/CMesh.cpp
+++ b/Project/Engine/CMesh.cpp
@@ -182,11 +182,11 @@ CMesh* CMesh::CreateFromContainer(CFBXLoader& _loader)
 		}
 
 		pMesh->m_pBoneOffset = new CStructuredBuffer;
-		pMesh->m_pBoneOffset->Create(sizeof(Matrix), (UINT)vecOffset.size(), SB_TYPE::READ_ONLY, false, vecOffset.data());
+		pMesh->m_pBoneOffset->Create(sizeof(Matrix), (UINT)vecOffset.size(), SB_READ_TYPE::READ_ONLY, false, vecOffset.data());
 
 		pMesh->m_pBoneFrameData = new CStructuredBuffer;
 		pMesh->m_pBoneFrameData->Create(sizeof(tFrameTrans), (UINT)vecOffset.size() * iFrameCount
-			, SB_TYPE::READ_ONLY, false, vecFrameTrans.data());
+			, SB_READ_TYPE::READ_ONLY, false, vecFrameTrans.data());
 	}
 
 	return pMesh;
@@ -483,11 +483,11 @@ int CMesh::Load(const wstring& _strFilePath)
 		}
 
 		m_pBoneOffset = new CStructuredBuffer;
-		m_pBoneOffset->Create(sizeof(Matrix), (UINT)vecOffset.size(), SB_TYPE::READ_ONLY, false, vecOffset.data());
+		m_pBoneOffset->Create(sizeof(Matrix), (UINT)vecOffset.size(), SB_READ_TYPE::READ_ONLY, false, vecOffset.data());
 
 		m_pBoneFrameData = new CStructuredBuffer;
 		m_pBoneFrameData->Create(sizeof(tFrameTrans), (UINT)vecOffset.size() * (UINT)_iFrameCount
-			, SB_TYPE::READ_ONLY, false, vecFrameTrans.data());
+			, SB_READ_TYPE::READ_ONLY, false, vecFrameTrans.data());
 	}
 
 	fclose(pFile);

--- a/Project/Engine/CMesh.h
+++ b/Project/Engine/CMesh.h
@@ -2,6 +2,9 @@
 #include "CAsset.h"
 
 #include "CFBXLoader.h"
+
+class CStructuredBuffer;
+
 struct tIndexInfo
 {
     ComPtr<ID3D11Buffer>    pIB;
@@ -26,9 +29,24 @@ private:
     // 하나의 버텍스버퍼에 여러개의 인덱스버퍼가 연결
     vector<tIndexInfo>		m_vecIdxInfo;
 
+    // Animation3D 정보
+    vector<tMTAnimClip>		m_vecAnimClip;
+    vector<tMTBone>			m_vecBones;
+
+    CStructuredBuffer* m_pBoneFrameData;   // 전체 본 프레임 정보(크기, 이동, 회전) (프레임 개수만큼)
+    CStructuredBuffer* m_pBoneOffset;	    // 각 뼈의 offset 행렬(각 뼈의 위치를 되돌리는 행렬) (1행 짜리)
+
 public:
     Vtx* GetVtxSysMem() { return (Vtx*)m_VtxSysMem; }
     UINT GetSubsetCount() { return (UINT)m_vecIdxInfo.size(); }
+
+    const vector<tMTBone>* GetBones() { return &m_vecBones; }
+    UINT GetBoneCount() { return (UINT)m_vecBones.size(); }
+    const vector<tMTAnimClip>* GetAnimClip() { return &m_vecAnimClip; }
+    bool IsAnimMesh() { return !m_vecAnimClip.empty(); }
+
+    CStructuredBuffer* GetBoneFrameDataBuffer() { return m_pBoneFrameData; } // 전체 본 프레임 정보
+    CStructuredBuffer* GetBoneOffsetBuffer() { return  m_pBoneOffset; }	   // 각 뼈의 offset 행렬
 
 private:
     void UpdateData(UINT _iSubset);
@@ -40,9 +58,9 @@ public:
     void render_asparticle(UINT _ParticleCount);
 
 private:
-    virtual int Load(const wstring& _strFilePath) override { return S_OK; }
+    virtual int Load(const wstring& _strFilePath) override;
 public:
-    virtual int Save(const wstring& _strRelativePath) override { return S_OK; }
+    virtual int Save(const wstring& _strRelativePath) override;
 
     CLONE_DISABLE(CMesh);
 public:

--- a/Project/Engine/CMeshData.cpp
+++ b/Project/Engine/CMeshData.cpp
@@ -65,7 +65,11 @@ CMeshData* CMeshData::LoadFromFBX(const wstring& _RelativePath)
 		wstring strMeshKey = L"mesh\\";
 		strMeshKey += path(strFullPath).stem();
 		strMeshKey += L".mesh";
-		CAssetMgr::GetInst()->AddAsset<CMesh>(strMeshKey, pMesh);
+
+		if (nullptr == CAssetMgr::GetInst()->FindAsset<CMesh>(strMeshKey))
+		{
+			CAssetMgr::GetInst()->AddAsset<CMesh>(strMeshKey, pMesh);
+		}
 
 		// 메시를 실제 파일로 저장
 		pMesh->Save(strMeshKey);

--- a/Project/Engine/CMeshData.cpp
+++ b/Project/Engine/CMeshData.cpp
@@ -7,6 +7,7 @@
 #include "CGameObject.h"
 #include "CTransform.h"
 #include "CMeshRender.h"
+#include "CAnimator3D.h"
 
 #include "CFBXLoader.h"
 
@@ -31,6 +32,16 @@ CGameObject* CMeshData::Instantiate()
 	{
 		pNewObj->MeshRender()->SetMaterial(m_vecMtrl[i], i);
 	}
+
+	// Animation 파트 추가
+	if (false == m_pMesh->IsAnimMesh())
+		return pNewObj;
+
+	CAnimator3D* pAnimator = new CAnimator3D;
+	pNewObj->AddComponent(pAnimator);
+
+	pAnimator->SetBones(m_pMesh->GetBones());
+	pAnimator->SetAnimClip(m_pMesh->GetAnimClip());
 
 	return pNewObj;
 }
@@ -80,13 +91,80 @@ CMeshData* CMeshData::LoadFromFBX(const wstring& _RelativePath)
 }
 
 
-int CMeshData::Save(const wstring&)
+int CMeshData::Save(const wstring& _strRelativePath)
 {
-	return 0;
+	SetRelativePath(_strRelativePath);
+
+	wstring strFilePath = CPathMgr::GetContentPath() + _strRelativePath;
+
+	FILE* pFile = nullptr;
+	errno_t err = _wfopen_s(&pFile, strFilePath.c_str(), L"wb");
+	assert(pFile);
+
+	// Mesh Key 저장	
+	// Mesh Data 저장
+	SaveAssetRef(m_pMesh, pFile);
+
+	// material 정보 저장
+	UINT iMtrlCount = (UINT)m_vecMtrl.size();
+	fwrite(&iMtrlCount, sizeof(UINT), 1, pFile);
+
+	UINT i = 0;
+	wstring strMtrlPath = CPathMgr::GetContentPath();
+	strMtrlPath += L"material\\";
+
+	for (; i < iMtrlCount; ++i)
+	{
+		if (nullptr == m_vecMtrl[i])
+			continue;
+
+		// Material 인덱스, Key, Path 저장
+		fwrite(&i, sizeof(UINT), 1, pFile);
+		SaveAssetRef(m_vecMtrl[i], pFile);
+	}
+
+	i = -1; // 마감 값
+	fwrite(&i, sizeof(UINT), 1, pFile);
+
+	fclose(pFile);
+
+	return S_OK;
 }
 
 int CMeshData::Load(const wstring& _strFilePath)
 {
-	return 0;
+	FILE* pFile = NULL;
+	_wfopen_s(&pFile, _strFilePath.c_str(), L"rb");
+
+	assert(pFile);
+
+	// Mesh Load
+	LoadAssetRef(m_pMesh, pFile);
+	assert(m_pMesh.Get());
+
+	// material 정보 읽기
+	UINT iMtrlCount = 0;
+	fread(&iMtrlCount, sizeof(UINT), 1, pFile);
+
+	m_vecMtrl.resize(iMtrlCount);
+
+	for (UINT i = 0; i < iMtrlCount; ++i)
+	{
+		UINT idx = -1;
+		fread(&idx, 4, 1, pFile);
+		if (idx == -1)
+			break;
+
+		wstring strKey, strPath;
+
+		Ptr<CMaterial> pMtrl;
+		LoadAssetRef(pMtrl, pFile);
+
+		m_vecMtrl[i] = pMtrl;
+	}
+
+	fclose(pFile);
+
+	return S_OK;
 }
 

--- a/Project/Engine/CMeshData.h
+++ b/Project/Engine/CMeshData.h
@@ -15,7 +15,7 @@ public:
 	CGameObject* Instantiate();
 
 	// 파일로 저장
-	virtual int Save(const wstring&) override;
+	virtual int Save(const wstring& _strRelativePath) override;
 
 	// 파일로부터 로딩
 	virtual int Load(const wstring& _strFilePath) override;

--- a/Project/Engine/CMeshRender.cpp
+++ b/Project/Engine/CMeshRender.cpp
@@ -50,6 +50,21 @@ void CMeshRender::render()
 		Animator2D()->Clear();
 	}
 
+	// Animator3D 업데이트
+	if (Animator3D())
+	{
+		Animator3D()->UpdateData();
+
+		for (UINT i = 0; i < GetMtrlCount(); ++i)
+		{
+			if (nullptr == GetMaterial(i))
+				continue;
+
+			GetMaterial(i)->SetAnim3D(true); // Animation Mesh 알리기
+			GetMaterial(i)->SetBoneCount(Animator3D()->GetBoneCount());
+		}
+	}
+
 	Transform()->UpdateData();
 
 	// 메쉬의 모든 부위를 렌더링한다.

--- a/Project/Engine/Engine.vcxproj
+++ b/Project/Engine/Engine.vcxproj
@@ -174,6 +174,8 @@ call CodeGen.exe</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="CAnimation3DShader.h" />
+    <ClInclude Include="CAnimator3D.h" />
     <ClInclude Include="CCameraShake.h" />
     <ClInclude Include="CAnim.h" />
     <ClInclude Include="CAsset.h" />
@@ -262,6 +264,8 @@ call CodeGen.exe</Command>
     <ClInclude Include="UserStrings.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="CAnimation3DShader.cpp" />
+    <ClCompile Include="CAnimator3D.cpp" />
     <ClCompile Include="CCameraShake.cpp" />
     <ClCompile Include="CAnim.cpp" />
     <ClCompile Include="CAsset.cpp" />
@@ -341,6 +345,16 @@ call CodeGen.exe</Command>
     <None Include="SimpleMath.inl" />
   </ItemGroup>
   <ItemGroup>
+    <FxCompile Include="animation.fx">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Effect</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Effect</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Effect</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Effect</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">5.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">5.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+    </FxCompile>
     <FxCompile Include="debug.fx">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Effect</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>

--- a/Project/Engine/Engine.vcxproj.filters
+++ b/Project/Engine/Engine.vcxproj.filters
@@ -259,6 +259,10 @@
     <ClInclude Include="strFBX.h">
       <Filter>01. Header\GenString</Filter>
     </ClInclude>
+    <ClInclude Include="CAnimation3DShader.h" />
+    <ClInclude Include="CAnimator3D.h">
+      <Filter>08. Component\05. Animator3D</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Engine.cpp">
@@ -467,6 +471,10 @@
     </ClCompile>
     <ClCompile Include="CMeshData.cpp">
       <Filter>06. Asset\MeshData</Filter>
+    </ClCompile>
+    <ClCompile Include="CAnimation3DShader.cpp" />
+    <ClCompile Include="CAnimator3D.cpp">
+      <Filter>08. Component\05. Animator3D</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -680,6 +688,9 @@
     <Filter Include="Module\FBXLoader">
       <UniqueIdentifier>{81e92f5f-7347-4b4b-9815-eb45c0544dfd}</UniqueIdentifier>
     </Filter>
+    <Filter Include="08. Component\05. Animator3D">
+      <UniqueIdentifier>{2605de3c-e5b1-4a58-ae2f-2d0f3190a6c0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="SimpleMath.inl">
@@ -752,6 +763,9 @@
     </FxCompile>
     <FxCompile Include="weightmap.fx">
       <Filter>ShaderCode\03. Compute\LandScape\WeightMap</Filter>
+    </FxCompile>
+    <FxCompile Include="animation.fx">
+      <Filter>ShaderCode\02. Render\3DShader</Filter>
     </FxCompile>
   </ItemGroup>
 </Project>

--- a/Project/Engine/animation.fx
+++ b/Project/Engine/animation.fx
@@ -1,0 +1,250 @@
+#ifndef _ANIMATION
+#define _ANIMATION
+
+#include "value.fx"
+
+float4 VectorLess(float4 _vQ1, float4 _vQ2)
+{
+    float4 vReturn =
+    {
+        (_vQ1[0] < _vQ2[0]) ? asfloat((uint) 0xFFFFFFFF) : 0.f,
+        (_vQ1[1] < _vQ2[1]) ? asfloat((uint) 0xFFFFFFFF) : 0.f,
+        (_vQ1[2] < _vQ2[2]) ? asfloat((uint) 0xFFFFFFFF) : 0.f,
+        (_vQ1[3] < _vQ2[3]) ? asfloat((uint) 0xFFFFFFFF) : 0.f
+    };
+
+    return vReturn;
+}
+
+void VectorPermute(uint PermuteX, uint PermuteY, uint PermuteZ, uint PermuteW
+    , in float4 V1, in float4 V2
+    , out float4 _vOut)
+{
+    float4 aPtr[2] = { V1, V2 };
+    float4 Result = (float4) 0.f;
+
+    const uint i0 = PermuteX & 3;
+    const uint vi0 = PermuteX >> 2;
+    Result[0] = aPtr[vi0][i0];
+
+    const uint i1 = PermuteY & 3;
+    const uint vi1 = PermuteY >> 2;
+    Result[1] = aPtr[vi1][i1];
+
+    const uint i2 = PermuteZ & 3;
+    const uint vi2 = PermuteZ >> 2;
+    Result[2] = aPtr[vi2][i2];
+
+    const uint i3 = PermuteW & 3;
+    const uint vi3 = PermuteW >> 2;
+    Result[3] = aPtr[vi3][i3];
+
+    _vOut = Result;
+}
+
+
+float4 VectorShiftLeft(in float4 _V1, in float4 _V2, uint _Elements)
+{
+    float4 vOut = (float4) 0.f;
+
+    VectorPermute(_Elements, ((_Elements) + 1), ((_Elements) + 2), ((_Elements) + 3), _V1, _V2, vOut);
+
+    return vOut;
+}
+
+float4 VectorSelect(float4 _vQ1, float4 _vQ2, float4 _vControl)
+{
+    uint4 iQ1 = asuint(_vQ1);
+    uint4 iQ2 = asuint(_vQ2);
+    uint4 iControl = asuint(_vControl);
+
+    int4 iReturn =
+    {
+        (iQ1[0] & ~iControl[0]) | (iQ2[0] & iControl[0]),
+        (iQ1[1] & ~iControl[1]) | (iQ2[1] & iControl[1]),
+        (iQ1[2] & ~iControl[2]) | (iQ2[2] & iControl[2]),
+        (iQ1[3] & ~iControl[3]) | (iQ2[3] & iControl[3]),
+    };
+
+    return asfloat(iReturn);
+}
+
+float4 VectorXorInt(float4 _V1, float4 _V2)
+{
+    uint4 iV1 = { asuint(_V1.x), asuint(_V1.y), asuint(_V1.z), asuint(_V1.w) };
+    uint4 iV2 = { 2147483648, 0, 0, 0 };
+
+    uint4 Result =
+    {
+        iV1[0] ^ iV2[0],
+        iV1[1] ^ iV2[1],
+        iV1[2] ^ iV2[2],
+        iV1[3] ^ iV2[3]
+    };
+
+    return float4(asfloat(Result.x), asfloat(Result.y), asfloat(Result.z), asfloat(Result.w));
+}
+
+
+void MatrixRotationQuaternion(in float4 Quaternion, out matrix _outMat)
+{
+    float4 Constant1110 = float4(1.f, 1.f, 1.f, 0.f);
+
+    float4 Q0 = Quaternion + Quaternion;
+    float4 Q1 = Quaternion * Q0;
+
+    float4 V0 = (float4) 0.f;
+    VectorPermute(1, 0, 0, 7, Q1, Constant1110, V0);
+
+    float4 V1 = (float4) 0.f;
+    VectorPermute(2, 2, 1, 7, Q1, Constant1110, V1);
+
+    float4 R0 = Constant1110 - V0;
+    R0 = R0 - V1;
+
+    V0 = float4(Quaternion[0], Quaternion[0], Quaternion[1], Quaternion[3]);
+    V1 = float4(Q0[2], Q0[1], Q0[2], Q0[3]);
+    V0 = V0 * V1;
+
+    V1 = float4(Quaternion.w, Quaternion.w, Quaternion.w, Quaternion.w);
+    float4 V2 = float4(Q0[1], Q0[2], Q0[0], Q0[3]);
+    V1 = V1 * V2;
+
+    float4 R1 = V0 + V1;
+    float4 R2 = V0 - V1;
+
+    VectorPermute(1, 4, 5, 2, R1, R2, V0);
+    VectorPermute(0, 6, 0, 6, R1, R2, V1);
+
+    matrix M = (matrix) 0.f;
+    VectorPermute(0, 4, 5, 3, R0, V0, M._11_12_13_14);
+    VectorPermute(6, 1, 7, 3, R0, V0, M._21_22_23_24);
+    VectorPermute(4, 5, 2, 3, R0, V1, M._31_32_33_34);
+    M._41_42_43_44 = float4(0.f, 0.f, 0.f, 1.f);
+    _outMat = M;
+}
+
+
+void MatrixAffineTransformation(in float4 Scaling
+    , in float4 RotationOrigin
+    , in float4 RotationQuaternion
+    , in float4 Translation
+    , out matrix _outMat)
+{
+    matrix MScaling = (matrix) 0.f;
+    MScaling._11_22_33 = Scaling.xyz;
+
+    float4 VRotationOrigin = float4(RotationOrigin.xyz, 0.f);
+    float4 VTranslation = float4(Translation.xyz, 0.f);
+
+    matrix MRotation = (matrix) 0.f;
+    MatrixRotationQuaternion(RotationQuaternion, MRotation);
+
+    matrix M = MScaling;
+    M._41_42_43_44 = M._41_42_43_44 - VRotationOrigin;
+    M = mul(M, MRotation);
+    M._41_42_43_44 = M._41_42_43_44 + VRotationOrigin;
+    M._41_42_43_44 = M._41_42_43_44 + VTranslation;
+    _outMat = M;
+}
+
+
+float4 QuternionLerp(in float4 _vQ1, in float4 _vQ2, float _fRatio)
+{
+    float4 vT = float4(_fRatio, _fRatio, _fRatio, _fRatio);
+
+    // Result = Q1 * sin((1.0 - t) * Omega) / sin(Omega) + Q2 * sin(t * Omega) / sin(Omega)
+    const float4 OneMinusEpsilon = { 1.0f - 0.00001f, 1.0f - 0.00001f, 1.0f - 0.00001f, 1.0f - 0.00001f };
+
+    float fQDot = dot(_vQ1, _vQ2);
+    float4 CosOmega = float4(fQDot, fQDot, fQDot, fQDot);
+
+    const float4 Zero = (float4) 0.f;
+    float4 Control = VectorLess(CosOmega, Zero);
+    float4 Sign = VectorSelect(float4(1.f, 1.f, 1.f, 1.f), float4(-1.f, -1.f, -1.f, -1.f), Control);
+
+    CosOmega = CosOmega * Sign;
+    Control = VectorLess(CosOmega, OneMinusEpsilon);
+
+    float4 SinOmega = float4(1.f, 1.f, 1.f, 1.f) - (CosOmega * CosOmega);
+    SinOmega = float4(sqrt(SinOmega.x), sqrt(SinOmega.y), sqrt(SinOmega.z), sqrt(SinOmega.w));
+
+    float4 Omega = float4(atan2(SinOmega.x, CosOmega.x)
+        , atan2(SinOmega.y, CosOmega.y)
+        , atan2(SinOmega.z, CosOmega.z)
+        , atan2(SinOmega.w, CosOmega.w));
+
+    float4 SignMask = float4(asfloat(0x80000000U), asfloat(0x80000000U), asfloat(0x80000000U), asfloat(0x80000000U));
+    float4 V01 = VectorShiftLeft(vT, Zero, 2);
+    SignMask = VectorShiftLeft(SignMask, Zero, 3);
+
+    V01 = VectorXorInt(V01, SignMask);
+    V01 = float4(1.0f, 0.0f, 0.0f, 0.0f) + V01;
+
+    float4 InvSinOmega = float4(1.f, 1.f, 1.f, 1.f) / SinOmega;
+
+    float4 S0 = V01 * Omega;
+    S0 = float4(sin(S0.x), sin(S0.y), sin(S0.z), sin(S0.w));
+    S0 = S0 * InvSinOmega;
+    S0 = VectorSelect(V01, S0, Control);
+
+    float4 S1 = float4(S0.y, S0.y, S0.y, S0.y);
+    S0 = float4(S0.x, S0.x, S0.x, S0.x);
+
+    S1 = S1 * Sign;
+
+    float4 Result = _vQ1 * S0;
+    Result = (_vQ2 * S1) + Result;
+
+    return Result;
+}
+
+struct tFrameTrans
+{
+    float4 vTranslate;
+    float4 vScale;
+    float4 qRot;
+};
+
+StructuredBuffer<tFrameTrans> g_arrFrameTrans : register(t16);
+StructuredBuffer<matrix> g_arrOffset : register(t17);
+RWStructuredBuffer<matrix> g_arrFinelMat : register(u0);
+
+// ===========================
+// Animation3D Compute Shader
+#define BoneCount   g_int_0
+#define CurFrame    g_int_1
+#define Ratio       g_float_0
+// ===========================
+[numthreads(256, 1, 1)]
+void CS_Animation3D(int3 _iThreadIdx : SV_DispatchThreadID)
+{
+    if (BoneCount <= _iThreadIdx.x)
+        return;
+
+    // 오프셋 행렬을 곱하여 최종 본행렬을 만들어낸다.		
+    float4 vQZero = float4(0.f, 0.f, 0.f, 1.f);
+    matrix matBone = (matrix) 0.f;
+
+    // Frame Data Index == Bone Count * Frame Count + _iThreadIdx.x
+    uint iFrameDataIndex = BoneCount * CurFrame + _iThreadIdx.x;
+    uint iNextFrameDataIdx = BoneCount * (CurFrame + 1) + _iThreadIdx.x;
+
+    float4 vScale = lerp(g_arrFrameTrans[iFrameDataIndex].vScale, g_arrFrameTrans[iNextFrameDataIdx].vScale, Ratio);
+    float4 vTrans = lerp(g_arrFrameTrans[iFrameDataIndex].vTranslate, g_arrFrameTrans[iNextFrameDataIdx].vTranslate, Ratio);
+    float4 qRot = QuternionLerp(g_arrFrameTrans[iFrameDataIndex].qRot, g_arrFrameTrans[iNextFrameDataIdx].qRot, Ratio);
+
+    // 최종 본행렬 연산
+    MatrixAffineTransformation(vScale, vQZero, qRot, vTrans, matBone);
+
+    // 최종 본행렬 연산    
+    //MatrixAffineTransformation(g_arrFrameTrans[iFrameDataIndex].vScale, vQZero, g_arrFrameTrans[iFrameDataIndex].qRot, g_arrFrameTrans[iFrameDataIndex].vTranslate, matBone);
+
+    matrix matOffset = transpose(g_arrOffset[_iThreadIdx.x]);
+
+    // 구조화버퍼에 결과값 저장
+    g_arrFinelMat[_iThreadIdx.x] = mul(matOffset, matBone);
+}
+
+
+#endif

--- a/Project/Engine/func.cpp
+++ b/Project/Engine/func.cpp
@@ -555,3 +555,16 @@ Vec3 DecomposeRotMat(const Matrix& _matRot)
 	}
 	return vNewRot;
 }
+
+Matrix GetMatrixFromFbxMatrix(FbxAMatrix& _mat)
+{
+	Matrix mat;
+	for (int i = 0; i < 4; ++i)
+	{
+		for (int j = 0; j < 4; ++j)
+		{
+			mat.m[i][j] = (float)_mat.Get(i, j);
+		}
+	}
+	return mat;
+}

--- a/Project/Engine/func.fx
+++ b/Project/Engine/func.fx
@@ -270,4 +270,37 @@ float GetTessFactor(float _Length, int _iMinLevel, int _iMaxLevel, float _MinDis
     }
 }
 
+matrix GetBoneMat(int _iBoneIdx, int _iRowIdx)
+{
+    return g_arrBoneMat[(g_iBoneCount * _iRowIdx) + _iBoneIdx];
+}
+
+void Skinning(inout float3 _vPos, inout float3 _vTangent, inout float3 _vBinormal, inout float3 _vNormal
+    , inout float4 _vWeight, inout float4 _vIndices
+    , int _iRowIdx)
+{
+    tSkinningInfo info = (tSkinningInfo) 0.f;
+
+    if (_iRowIdx == -1)
+        return;
+
+    for (int i = 0; i < 4; ++i)
+    {
+        if (0.f == _vWeight[i])
+            continue;
+
+        matrix matBone = GetBoneMat((int) _vIndices[i], _iRowIdx);
+
+        info.vPos += (mul(float4(_vPos, 1.f), matBone) * _vWeight[i]).xyz;
+        info.vTangent += (mul(float4(_vTangent, 0.f), matBone) * _vWeight[i]).xyz;
+        info.vBinormal += (mul(float4(_vBinormal, 0.f), matBone) * _vWeight[i]).xyz;
+        info.vNormal += (mul(float4(_vNormal, 0.f), matBone) * _vWeight[i]).xyz;
+    }
+
+    _vPos = info.vPos;
+    _vTangent = normalize(info.vTangent);
+    _vBinormal = normalize(info.vBinormal);
+    _vNormal = normalize(info.vNormal);
+}
+
 #endif

--- a/Project/Engine/func.h
+++ b/Project/Engine/func.h
@@ -137,6 +137,7 @@ void LoadWString(wstring& _str, FILE* _FILE);
 
 Vec3 DecomposeRotMat(const Matrix& _matRot);
 
+Matrix GetMatrixFromFbxMatrix(FbxAMatrix& _mat);
 
 template<typename T>
 class Ptr;

--- a/Project/Engine/std3d_deferred.fx
+++ b/Project/Engine/std3d_deferred.fx
@@ -24,6 +24,8 @@ struct VS_IN
     float3 vNormal : NORMAL;
     float3 vBinormal : BINORMAL;
     
+    float4 vWeights : BLENDWEIGHT;
+    float4 vIndices : BLENDINDICES;
 };
 
 struct VS_OUT
@@ -65,6 +67,12 @@ struct PS_OUT
 PS_OUT PS_Std3D_Deferred(VS_OUT _in) : SV_Target
 {
     PS_OUT output = (PS_OUT) 0.f;
+    
+    if (g_iAnim)
+    {
+        Skinning(_in.vPos, _in.vTangent, _in.vBinormal, _in.vNormal
+              , _in.vWeights, _in.vIndices, 0);
+    }
     
     float4 vOutColor = float4(1.f, 0.f, 1.f, 1.f);
     

--- a/Project/Engine/std3d_deferred.fx
+++ b/Project/Engine/std3d_deferred.fx
@@ -2,6 +2,7 @@
 #define _STD_DEFERRED
 
 #include "value.fx"
+#include "func.fx"
 
 // ======================
 // Std3D_Deferred Shader
@@ -42,6 +43,12 @@ struct VS_OUT
 VS_OUT VS_Std3D_Deferred(VS_IN _in)
 {
     VS_OUT output = (VS_OUT) 0.f;
+        
+    if (g_iAnim)
+    {
+        Skinning(_in.vPos, _in.vTangent, _in.vBinormal, _in.vNormal
+              , _in.vWeights, _in.vIndices, 0);
+    }
     
     output.vPosition = mul(float4(_in.vPos, 1.f), g_matWVP);
     output.vUV = _in.vUV;
@@ -50,8 +57,6 @@ VS_OUT VS_Std3D_Deferred(VS_IN _in)
     output.vViewTangent = normalize(mul(float4(_in.vTangent, 0.f), g_matWV));
     output.vViewNormal = normalize(mul(float4(_in.vNormal, 0.f), g_matWV));;
     output.vViewBinormal = normalize(mul(float4(_in.vBinormal, 0.f), g_matWV));;
-    
-    
     
     return output;
 }
@@ -67,12 +72,6 @@ struct PS_OUT
 PS_OUT PS_Std3D_Deferred(VS_OUT _in) : SV_Target
 {
     PS_OUT output = (PS_OUT) 0.f;
-    
-    if (g_iAnim)
-    {
-        Skinning(_in.vPos, _in.vTangent, _in.vBinormal, _in.vNormal
-              , _in.vWeights, _in.vIndices, 0);
-    }
     
     float4 vOutColor = float4(1.f, 0.f, 1.f, 1.f);
     

--- a/Project/Engine/struct.fx
+++ b/Project/Engine/struct.fx
@@ -109,4 +109,12 @@ struct tRaycastOut
     int success;
 };
 
+struct tSkinningInfo
+{
+    float3 vPos;
+    float3 vTangent;
+    float3 vBinormal;
+    float3 vNormal;
+};
+
 #endif

--- a/Project/Engine/struct.h
+++ b/Project/Engine/struct.h
@@ -11,6 +11,9 @@ struct Vtx
 	Vec3 vTangent;	// 접선 벡터
 	Vec3 vNormal;	// 법선 벡터
 	Vec3 vBinormal;	// 종법선 벡터
+
+	Vec4 vWeights;  // Bone 가중치
+	Vec4 vIndices;  // Bone 인덱스
 };
 
 struct tDebugShapeInfo
@@ -140,6 +143,50 @@ struct tSpawnCount
 	int iPadding[3];
 };
 
+// ============
+// Animation 3D
+// ============
+struct tFrameTrans
+{
+	Vec4	vTranslate;
+	Vec4	vScale;
+	Vec4	qRot;
+};
+
+struct tMTKeyFrame
+{
+	double	dTime;
+	int		iFrame;
+	Vec3	vTranslate;
+	Vec3	vScale;
+	Vec4	qRot;
+};
+
+
+struct tMTBone
+{
+	wstring				strBoneName;
+	int					iDepth;
+	int					iParentIndx;
+	Matrix				matOffset;	// Offset 행렬(뼈 -> 루트 까지의 행렬)
+	Matrix				matBone;   // 이거 안씀
+	vector<tMTKeyFrame>	vecKeyFrame;
+};
+
+struct tMTAnimClip
+{
+	wstring			strAnimName;
+	int				iStartFrame;
+	int				iEndFrame;
+	int				iFrameLength;
+
+	double			dStartTime;
+	double			dEndTime;
+	double			dTimeLength;
+	float			fUpdateTime; // 이거 안씀
+
+	FbxTime::EMode	eMode;
+};
 
 // ==================
 // 상수버퍼 대응 구조체
@@ -180,7 +227,9 @@ struct tMtrlConst
 	Vec4 v4Arr[4];
 	Matrix matArr[4];
 	int	bTex[(UINT)TEX_PARAM::END];
-	int iPadding[2];
+
+	// 3D Animation 정보
+	int	arrAnimData[2];
 
 	friend ofstream& operator<<(ofstream& fout, const tMtrlConst& _mtrlConst);
 	friend ifstream& operator>>(ifstream& fin, tMtrlConst& _mtrlConst);

--- a/Project/Engine/value.fx
+++ b/Project/Engine/value.fx
@@ -69,6 +69,11 @@ cbuffer MATERIAL_CONST : register(b1)
     int g_btexcube_1;
     int g_btexarr_0;
     int g_btexarr_1;
+    
+    // 3D Animation 정보
+    int g_iAnim;
+    int g_iBoneCount;
+    
 }
 
 cbuffer ANIM_DATA2D : register(b2)
@@ -124,5 +129,7 @@ Texture2D g_NoiseTex : register(t14);
 SamplerState g_sam_0 : register(s0);
 SamplerState g_sam_1 : register(s1);
 
+// Animation3D Bone Matrix Buffer
+StructuredBuffer<Matrix> g_arrBoneMat : register(t30);
 
 #endif


### PR DESCRIPTION
// meshData 저장 및 Animator3D 컴포넌트 추가

1. Vertex 의 구조 변경
 - BlendWeights, BlendIndices 추가
 - 이에 따른 Layout 생성 구조 변경 ( GraphicsShader CreateVertexShader)

2. CMesh 에 3D Animation 관련 데이터 추가
  - Bone 정보 벡터
  - Key Frame 별 Bone 행렬 정보를 저장하는 구조화 버퍼

3. MeshData Save / Load 추가
  - 연관된 CMesh 도 Save / Load 추가

4. CAnimator3D 컴포넌트 추가
  - 3DAnimation 기능을 수행 할 수 있게 해주는 Component 임
  - MeshData 를 Instantiate 할 때 로딩된 CMesh 의 정보안에 Animation 정보가 들어있다면 CAnimator3D 컴포넌트도 붙여서 생성시킴
  - Material 상수 구조체에, 해당 물체를 렌더링 시에 이게 3DAniamtion 정보가 있는지 없는지 전달하기 위한 상수를 추가함
  - value.fx 의 재질 b1 상수 레지스터 선언도 확인할 것

5. CAnimator3D 컴포넌트에 의해서 전달된 행렬정보를 정점 쉐이더에서 Skinning 작업에 사용함
  - Func.fx 의 Skinning 함수 확인 할 것
  - value.fx 에 Bone FinalMatrix 전달받는 텍스쳐 레지스터(t30 으로 지정함) 확인 할 것
  - CAnimator3D 컴포넌트는 Animation 행렬을 계산하고 FinalMatrix 로 복사하는 과정을 컴퓨트 쉐이더를 통해서 진행함
    따라서 CResMgr::init 에서 해당 컴퓨트 쉐이더 "CAnimation3DShader.h" 를 생성했는지 확인할 것


6. 로딩하는 과정에서 content 폴더에 다음 이름이 폴더가 생성되어있는지 확인할 것
 -  mesh, meshdata, material, texture, fbx

MeshData::CreateFromContainer 함수에서 메시를 에셋매니저에 등록할때 조건 예외처리 추가