### PR TITLE
Feat/#198 phys x offset pos scale

### DIFF
--- a/Project/Client/PhysXUI.cpp
+++ b/Project/Client/PhysXUI.cpp
@@ -1,9 +1,10 @@
 ﻿#include "pch.h"
 #include "PhysXUI.h"
 #include "Engine\CPhysX.h"
+#include "Engine\CTransform.h"
 
 PhysXUI::PhysXUI()
-	: ComponentUI("PhysXUI", "##PhysXUI", COMPONENT_TYPE::PHYSX)
+	: ComponentUI("PhysX", "##PhysX", COMPONENT_TYPE::PHYSX)
 {
 	SetComponentTitle("PhysX");
 }
@@ -16,7 +17,7 @@ void PhysXUI::render_update()
 {
 	ComponentUI::render_update();
 
-	if (!TitleCollapse("PhysXUI"))
+	if (!TitleCollapse("PhysX"))
 		return;
 
 	auto TGO = GetTargetObject();
@@ -32,6 +33,12 @@ void PhysXUI::render_update()
 
 	static auto Shape	 = phys->m_Shape;
 	auto		strShape = ToString(magic_enum::enum_name<PhysShape>(Shape));
+
+	static auto IsStatic = phys->m_bStaticActor;
+	if (ImGui::Checkbox("IsStatic", &IsStatic))
+	{
+		phys->m_bStaticActor = IsStatic;
+	}
 
 	if (ImGui::BeginCombo("##Shape", strShape.c_str()))
 	{
@@ -53,11 +60,17 @@ void PhysXUI::render_update()
 		ImGui::EndCombo();
 	}
 
-	static auto IsStatic = phys->m_bStaticActor;
-	if (ImGui::Checkbox("IsStatic", &IsStatic))
+	Vec3 Scale = phys->m_vScale;
+	if (Vec3() == Scale && nullptr != phys->Transform())
 	{
-		phys->m_bStaticActor = IsStatic;
+		Scale = phys->Transform()->GetRelativeScale();
 	}
+	ImGui::DragFloat3("Scale", (float*)Scale);
+	phys->m_vScale = Scale;
+
+	Vec3 OffsetPos = phys->m_vOffsetPos;
+	ImGui::DragFloat3("OffsetPos", (float*)OffsetPos);
+	phys->m_vOffsetPos = OffsetPos;
 
 	phys->m_bImguiDirtyFlag	   = true;
 	const auto& vecContactInfo = phys->m_vThisFrameContact;

--- a/Project/Engine/CPhysX.cpp
+++ b/Project/Engine/CPhysX.cpp
@@ -137,6 +137,8 @@ void CPhysX::finaltick()
 
 #define TagStatic "[IsStatic]"
 #define TagShape "[Shape]"
+#define TagScale "[Scale]"
+#define TagOffsetPos "[OffsetPos]"
 void CPhysX::SaveToFile(FILE* _File)
 {
 }
@@ -149,6 +151,12 @@ void CPhysX::SaveToFile(ofstream& fout)
 	fout << TagShape << endl;
 	auto shape = magic_enum::enum_name<PhysShape>(m_Shape);
 	fout << ToString(shape) << endl;
+
+	fout << TagScale << endl;
+	fout << m_vScale << endl;
+
+	fout << TagOffsetPos << endl;
+	fout << m_vOffsetPos << endl;
 }
 
 void CPhysX::LoadFromFile(FILE* _File)
@@ -164,6 +172,12 @@ void CPhysX::LoadFromFile(ifstream& fin)
 	Utils::GetLineUntilString(fin, TagShape);
 	getline(fin, str);
 	m_Shape = magic_enum::enum_cast<PhysShape>(str).value();
+
+	Utils::GetLineUntilString(fin, TagScale);
+	fin >> m_vScale;
+
+	Utils::GetLineUntilString(fin, TagOffsetPos);
+	fin >> m_vOffsetPos;
 }
 
 void CPhysX::setTransform(const PxTransform& transform)

--- a/Project/Engine/CPhysX.cpp
+++ b/Project/Engine/CPhysX.cpp
@@ -83,7 +83,7 @@ void CPhysX::updateToPhysics()
 
 void CPhysX::begin()
 {
-	CPhysXMgr::GetInst()->addGameObject(GetOwner(), m_bStaticActor, m_Shape);
+	CPhysXMgr::GetInst()->addGameObject(GetOwner());
 }
 
 void CPhysX::finaltick()

--- a/Project/Engine/CPhysX.cpp
+++ b/Project/Engine/CPhysX.cpp
@@ -120,7 +120,7 @@ void CPhysX::finaltick()
 		return;
 	const auto& trans		  = Transform();
 	auto		ObjWorldPos	  = trans->GetWorldPos();
-	auto		DebugFinalPos = ObjWorldPos - m_vOffsetPos;
+	auto		DebugFinalPos = ObjWorldPos + m_vOffsetPos;
 	auto		Rot			  = getTransform().q;
 
 	if (PhysShape::BOX == m_Shape)
@@ -130,8 +130,7 @@ void CPhysX::finaltick()
 	}
 	else
 	{
-		GamePlayStatic::DrawDebugSphere(trans->GetWorldPos() - m_vOffsetPos, m_vScale.x / 2.f, Vec3(0.3f, .3f, 0.3f),
-										true);
+		GamePlayStatic::DrawDebugSphere(DebugFinalPos, m_vScale.x / 2.f, Vec3(0.3f, .3f, 0.3f), true);
 	}
 }
 

--- a/Project/Engine/CPhysX.cpp
+++ b/Project/Engine/CPhysX.cpp
@@ -67,7 +67,7 @@ void CPhysX::updateToPhysics()
 
 	auto Obj = GetOwner();
 	auto Rot = Obj->Transform()->GetWorldRot();
-	auto Pos = Obj->Transform()->GetWorldPos();
+	auto Pos = Obj->Transform()->GetWorldPos() + m_vOffsetPos;
 
 	Matrix worldMat	   = Obj->Transform()->GetWorldMat();
 	Matrix transInvMat = Matrix::CreateTranslation(worldMat.Translation()).Invert();

--- a/Project/Engine/CPhysX.h
+++ b/Project/Engine/CPhysX.h
@@ -37,9 +37,11 @@ private:
 	void EndOverlap(CGameObject* other);
 
 public:
-	PhysShape			   m_Shape = PhysShape::BOX;
 	vector<tCollisionData> m_vThisFrameContact;
 	bool				   m_bStaticActor = false;
+	PhysShape			   m_Shape		  = PhysShape::BOX;
+	Vec3				   m_vScale;
+	Vec3				   m_vOffsetPos;
 	virtual void		   begin() override;
 	virtual void		   finaltick() override;
 

--- a/Project/Engine/CPhysXMgr.cpp
+++ b/Project/Engine/CPhysXMgr.cpp
@@ -213,7 +213,8 @@ void CPhysXMgr::addGameObject(CGameObject* object)
 	auto scale = PhysX->m_vScale;
 	if (Vec3() == scale)
 	{
-		scale = object->Transform()->GetWorldScale();
+		scale			= object->Transform()->GetWorldScale();
+		PhysX->m_vScale = scale;
 	}
 	PxShape* shape;
 

--- a/Project/Engine/CPhysXMgr.cpp
+++ b/Project/Engine/CPhysXMgr.cpp
@@ -188,7 +188,7 @@ void CPhysXMgr::addGameObject(CGameObject* object)
 
 	auto ObjPos	   = object->Transform()->GetWorldPos();
 	auto OffsetPos = PhysX->m_vOffsetPos;
-	auto FinalPos  = ObjPos + OffsetPos;
+	auto FinalPos  = ObjPos - OffsetPos;
 
 	// 게임 오브젝트의 위치와 회전 정보
 	PxTransform transform(PxVec3(FinalPos.x, FinalPos.y, FinalPos.z),

--- a/Project/Engine/CPhysXMgr.cpp
+++ b/Project/Engine/CPhysXMgr.cpp
@@ -188,7 +188,7 @@ void CPhysXMgr::addGameObject(CGameObject* object)
 
 	auto ObjPos	   = object->Transform()->GetWorldPos();
 	auto OffsetPos = PhysX->m_vOffsetPos;
-	auto FinalPos  = ObjPos - OffsetPos;
+	auto FinalPos  = ObjPos + OffsetPos;
 
 	// 게임 오브젝트의 위치와 회전 정보
 	PxTransform transform(PxVec3(FinalPos.x, FinalPos.y, FinalPos.z),

--- a/Project/Engine/CPhysXMgr.h
+++ b/Project/Engine/CPhysXMgr.h
@@ -89,7 +89,7 @@ public:
 	virtual void tick() override;
 	virtual void enter() override {}
 	virtual void exit() override;
-	void		 addGameObject(CGameObject* object, bool _bStatic, PhysShape _Shape = PhysShape::BOX);
+	void		 addGameObject(CGameObject* object);
 
 	bool PerfomRaycast(Vec3 _OriginPos, Vec3 _Dir, tRoRHitInfo& _HitInfo, UINT _LAYER = (UINT)LAYER::LAYER_RAYCAST,
 					   int _DebugFlagMask = RayCastDebugFlag::StartEndVisible);

--- a/Project/Engine/func.cpp
+++ b/Project/Engine/func.cpp
@@ -106,6 +106,26 @@ void GamePlayStatic::DrawDebugCube(Vec3 _vWorldPos, Vec3 _vWorldScale, Vec3 _vWo
 	CRenderMgr::GetInst()->AddDebugShapeInfo(info);
 }
 
+void GamePlayStatic::DrawDebugCube(Vec3 _vWorldPos, Vec3 _vWorldScale, Vec4 _qWorldRot, Vec3 _Color, bool _bDepthTest,
+								   float _Duration)
+{
+	tDebugShapeInfo info = {};
+	info.eShape			 = DEBUG_SHAPE::CUBE;
+
+	info.vWorldPos			= _vWorldPos;
+	info.vWorldScale		= _vWorldScale;
+	XMMATRIX rotationMatrix = XMMatrixRotationQuaternion(_qWorldRot);
+
+	info.matWorld = XMMatrixScaling(info.vWorldScale.x, info.vWorldScale.y, info.vWorldScale.z) * rotationMatrix *
+					XMMatrixTranslation(info.vWorldPos.x, info.vWorldPos.y, info.vWorldPos.z);
+
+	info.vColor		= _Color;
+	info.bDepthTest = _bDepthTest;
+	info.fDuration	= _Duration;
+
+	CRenderMgr::GetInst()->AddDebugShapeInfo(info);
+}
+
 void GamePlayStatic::DrawDebugSphere(Vec3 _vWorldPos, float _fRadius, Vec3 _Color, bool _bDepthTest, float _Duration)
 {
 	tDebugShapeInfo info = {};

--- a/Project/Engine/func.h
+++ b/Project/Engine/func.h
@@ -50,13 +50,17 @@ void Play2DSound(const wstring& _SoundPath, int _Loop, float _Volume, bool _Over
 void Play2DBGM(const wstring& _SoundPath, float _Volume);
 
 void DrawDebugCube(const Matrix& _WorldMat, Vec3 _Color, bool _bDepthTest, float _Duration = 0.f);
+// 회전에 문제가 있을 수 있음
 void DrawDebugCube(Vec3 _vWorldPos, Vec3 _vWorldScale, Vec3 _vWorldRot, Vec3 _Color, bool _bDepthTest,
+				   float _Duration = 0.f);
+void DrawDebugCube(Vec3 _vWorldPos, Vec3 _vWorldScale, Vec4 _qWorldRot, Vec3 _Color, bool _bDepthTest,
 				   float _Duration = 0.f);
 
 void DrawDebugSphere(Vec3 _vWorldPos, float _fRadius, Vec3 _Color, bool _bDepthTest, float _Duration = 0.f);
 void DrawDebugCylinder(Vec3 _FromPos, Vec3 _ToPos, float _LineWidth, Vec3 _Color, bool _bDepthTest,
 					   float _Duration = 0.f);
 
+// 회전에 문제가 있을 수 있음
 void DrawDebugCone(Vec3 _vWorldPos, Vec3 _vWorldScale, Vec3 _vWorldRot, Vec3 _Color, bool _bDepthTest,
 				   float _Duration = 0.f);
 

--- a/Project/Engine/global.h
+++ b/Project/Engine/global.h
@@ -85,5 +85,6 @@ typedef Vector4 Vec4;
 #include "UserStrings.h"
 
 // physx
+// dependency : vcpkg install physx:x64-windows
 #include "physx/PxPhysicsAPI.h"
 using namespace physx;


### PR DESCRIPTION
1. 오프셋포지션추가
2. 스케일지정추가(지정안하면 transform의 스케일가져옴
3. 디버그도형 위의 변경에맞춰수정
4. 세이브로드 변경내용에맞춰수정

제한사항
1. rigid액터는 scale ,offset, transform을 동적으로 변경불가(begin에서 한번만설정,이후 physx월드의 변경사항에따름)
2. static액터는 scale을 동적으로 변경불가 , offset,transform은 동적으로 변경가능